### PR TITLE
fix(ci): bump Rust to 1.85 for edition 2024 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83-slim AS builder
+FROM rust:1.85-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
The nybbles transitive dependency requires Rust edition 2024, which is stabilized starting in Rust 1.85.

https://claude.ai/code/session_011CgP8bdrSSTsGDiV7rZ2uC