### PR TITLE
Upgrade Rust base image from 1.85 to 1.91 to satisfy dependency requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-slim AS builder
+FROM rust:1.91-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
alloy 1.7.3 and related crates require rustc 1.91, which was not
met by the rust:1.85-slim Docker image.

https://claude.ai/code/session_01QzFhfgyydKdi4v341AEA6V